### PR TITLE
chore: release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - Unreleased
+## [1.0.0] - 2026-08-09
 
 A full rewrite. The import name, the API and the rendering engine all change,
 so 0.x code does not run against this release. See

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "website2pdf"
-version = "1.0.0.dev0"
+version = "1.0.0"
 description = "Fast, typed Python library and CLI to render web pages and local HTML files to PDF."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -18,7 +18,7 @@ authors = [{ name = "uNickz", email = "unickz.dev@gmail.com" }]
 maintainers = [{ name = "uNickz", email = "unickz.dev@gmail.com" }]
 keywords = ["pdf", "html", "website", "converter", "playwright", "chromium", "print"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",

--- a/uv.lock
+++ b/uv.lock
@@ -1477,7 +1477,7 @@ wheels = [
 
 [[package]]
 name = "website2pdf"
-version = "1.0.0.dev0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "playwright" },


### PR DESCRIPTION
Prepares the 1.0.0 release.

- Drops the `.dev0` suffix from the version.
- Dates the changelog entry.
- Moves the development status classifier to Production/Stable, which is what
  the version number already claims.
- Relocks `uv.lock`, which records the project's own version. Bumping
  `pyproject.toml` alone would have left `uv sync --locked` failing on every CI
  job.

Verified locally before pushing: ruff, mypy strict, 197 tests, `uv build`,
`twine check --strict`, and the tag guard in `release.yml`, which accepts
`v1.0.0` and rejects `v1.0.1` against this version.

Merging this does not publish anything. Publication happens when `v1.0.0` is
tagged and pushed, which requires the PyPI Trusted Publisher to be configured
first.
